### PR TITLE
Remove AWS logo from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,6 @@ We appreciate deeply any feedback that you may have! Feel free to participate in
 
 Special thanks to the following gold sponsors of this project:
 
-[![Supported by Amazon Web Services](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/aws.png "Supported by Amazon Web Services")](https://github.com/aws)
 [![Supported by Clarius](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/clarius.png "Supported by Clarius")](https://github.com/clarius)
 
 And to all our sponsors!


### PR DESCRIPTION
Removes AWS sponsorship listing from the readme. We acknowledge that we sponsored in the past. However, the addition of SponsorLink means that we will no longer be using this tool, and don’t wish to have our implied endorsement prominently displayed in the README. Thanks.