### PR TITLE
Remove AWS sponsorship from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,17 +109,6 @@ We appreciate deeply any feedback that you may have! Feel free to participate in
 
 <!-- #features -->
 <!-- #sponsors -->
-
-![Sponsors](https://raw.githubusercontent.com/devlooped/sponsors/main/assets/sponsors.svg) Sponsors
-============
-
-Special thanks to the following gold sponsors of this project:
-
-[![Supported by Amazon Web Services](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/aws.png "Supported by Amazon Web Services")](https://github.com/aws)
-[![Supported by Clarius](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/clarius.png "Supported by Clarius")](https://github.com/clarius)
-
-And to all our sponsors!
-
 <!-- include https://raw.githubusercontent.com/devlooped/sponsors/main/footer.md -->
 # Sponsors 
 


### PR DESCRIPTION
Whole section is unnecessary now, since the auto-updated section should be enough.

Fixes #1381